### PR TITLE
removing a hyphen from text in account view

### DIFF
--- a/view/Message:Mothership:User/account/account.html.twig
+++ b/view/Message:Mothership:User/account/account.html.twig
@@ -11,7 +11,7 @@
 			<dl>
 				<dt>Name</dt>
 					<dd>{{user.forename}} {{ user.surname }}</dd>
-				<dt>E-Mail-Address</dt>
+				<dt>E-Mail Address</dt>
 					<dd>{{ user.email }}</dd>
 			</dl>
 		</div>


### PR DESCRIPTION
This is the smallest commit. 

It’s just removing a hyphen from some text in the account view. 

Yup. 

Closes #58
