### PR TITLE
Fix single page menus

### DIFF
--- a/app/site/src/Controller/Module/Menu.php
+++ b/app/site/src/Controller/Module/Menu.php
@@ -18,7 +18,12 @@ class Menu extends Controller
 			->includeDeleted(false)
 			->includeUnpublished(false)
 			->getChildren($page);
-		$pages = ($pages) ? (array) $pages : [];
+
+		$pages = $pages ? $pages : [];
+
+		if (!is_array($pages)) {
+			$pages = [$pages];
+		}
 
 		if ($currentPage && (null === $active)) {
 			$this->_setActiveItems($currentPage);
@@ -37,7 +42,12 @@ class Menu extends Controller
 	public function footer()
 	{
 		$pages = $this->get('cms.page.loader')->getByTag(self::FOOTER_TAG);
-		$pages = ($pages) ? (array) $pages : [];
+
+		$pages = $pages ? $pages : [];
+
+		if (!is_array($pages)) {
+			$pages = [$pages];
+		}
 
 		$children = [];
 


### PR DESCRIPTION
There was an issue where a menu would break if there was only one page in it. This is caused by an incorrect use of type casting when building the menus. Casting `$page` to an array does not result in `[$page]` but rather, casts the top level of the page to an array
