### PR TITLE
Pre-load page content before sorting pages in blog listing

### DIFF
--- a/app/site/src/Controller/Module/Blog.php
+++ b/app/site/src/Controller/Module/Blog.php
@@ -35,6 +35,11 @@ class Blog extends Controller
 
 	protected function _sortPages($pages, $sort = null)
 	{
+		// Pre-load content to prevent errors with data changing in usort() call
+		foreach ($pages as $page) {
+			$page->getContent();
+		}
+
 		if ($sort === null) {
 			usort($pages, function($a, $b) {
 				if (!$a instanceof Page\Page || !$b instanceof Page\Page) {


### PR DESCRIPTION
This PR fixes the issue where the `usort()` call can break if the page content has not already been loaded, as the objects change within the closure. This is resolved by pre-loading the content before the function is called. Not the most elegant solution, but it's more elegant than a fatal error.
